### PR TITLE
Erste Vorschläge für Anpassungen WIT

### DIFF
--- a/classes/class.ilEventoImportImport.php
+++ b/classes/class.ilEventoImportImport.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * Copyright (c) 2017 Hochschule Luzern
@@ -23,144 +23,101 @@
 use EventoImport\communication\request_services\RequestClientService;
 use EventoImport\communication\ImporterApiSettings;
 use EventoImport\communication\request_services\RestClientService;
+use EventoImport\communication\EventoUserImporter;
+use EventoImport\communication\EventoEventImporter;
+use EventoImport\communication\EventoUserPhotoImporter;
+use EventoImport\communication\EventoAdminImporter;
+use EventoImport\import\EventoImportBootstrap;
+use EventoImport\import\action\user\UserActionFactory;
+use EventoImport\import\action\event\EventActionFactory;
+use EventoImport\import\data_matching\UserActionDecider;
+use EventoImport\import\data_matching\EventImportActionDecider;
+use ILIAS\DI\RBACServices;
+use ILIAS\Refinery\Factory;
 
 /**
- * Class ilEventoImportImport
- *
  * @author Stephan Winiker <stephan.winiker@hslu.ch>
  */
 
 class ilEventoImportImport extends ilCronJob
 {
-    
-    /**
-     * @var string The ID of the cron job
-     */
     const ID = "crevento_import";
     
-    private $rbac;
-    private $db;
+    private RBACServices $rbac;
+    private ilDBInterface $db;
 
-    private $refinery;
-    private $cp;
-    private $settings;
+    private Factory $refinery;
+    private ilEventoImportPlugin $cp;
+    private ilSetting $settings;
     private $importUsersConfig;
-    private $page_size;
+    private int $page_size;
 
-    /** @var \EventoImport\import\EventoImportBootstrap */
-    private \EventoImport\import\EventoImportBootstrap $import_bootstrapping;
-
-    /**
-     * Constructor
-     */
-    public function __construct(\ILIAS\DI\RBACServices $rbac_services = null, ilDBInterface $db = null)
-    {
-        global $DIC;
-        $this->rbac = $rbac_services ?? $DIC->rbac();
-        $this->db = $db ?? $DIC->database();
-        $this->refinery = $DIC->refinery();
-        //This is a workaround to avoid problems with missing templates
-        if (!method_exists($DIC, 'ui') || !method_exists($DIC->ui(), 'factory') || !isset($DIC['ui.factory'])) {
-            ilInitialisation::initUIFramework($DIC);
-            ilStyleDefinition::setCurrentStyle('Desktop');
-        }
-        $this->cp = new ilEventoImportPlugin();
-        $this->settings = new ilSetting("crevento");
-        $this->import_bootstrapping = new \EventoImport\import\EventoImportBootstrap($this->db, $this->rbac);
+    private EventoImportBootstrap $import_bootstrapping;
+    
+    public function __construct(
+        ilEventoImportPlugin $cp,
+        RBACServices $rbac_services,
+        ilDBInterface $db,
+        Factory $refinery,
+        ilSetting $settings
+    ) {
+        $this->cp = $cp;
+        $this->rbac = $rbac_services;
+        $this->db = $db;
+        $this->refinery = $refinery;
+        $this->settings = $settings;
+        
+        $this->import_bootstrapping = new EventoImportBootstrap($this->db, $this->rbac, $this->settings);
 
         $this->page_size = 500;
     }
-
-    /**
-     * Retrieve the ID of the cron job
-     * @return string
-     */
-    public function getId()
+    
+    public function getId() : string
     {
         return self::ID;
     }
     
-    /**
-     * Cron job will not be activated on Plugin activation
-     *
-     * @return bool
-     */
-    public function hasAutoActivation()
+    public function hasAutoActivation() : bool
     {
         return false;
     }
     
-    /**
-     * Cron job schedule can be set in the interface
-     *
-     * @return bool
-     */
-    public function hasFlexibleSchedule()
+    public function hasFlexibleSchedule() : bool
     {
         return true;
     }
     
-    /**
-     * Cron job schedule is set to daily by default
-     *
-     * @return int
-     */
-    public function getDefaultScheduleType()
+    public function getDefaultScheduleType() : int
     {
         return self::SCHEDULE_TYPE_DAILY;
     }
     
-    /**
-     * Defines the interval between cron job runs in SCHEDULE_TYPE
-     *
-     * @return array|int
-     */
-    public function getDefaultScheduleValue()
+    public function getDefaultScheduleValue() : int
     {
         return 1;
     }
     
-    /**
-     * Get title
-     *
-     * @return string
-     */
-    public function getTitle()
+    public function getTitle() : string
     {
         return $this->cp->txt("title");
     }
     
-    /**
-     * Get description
-     *
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription() : string
     {
         return $this->cp->txt("description");
     }
     
-    /**
-     * Cron job can be started manually
-     *
-     * @return bool
-     */
-    public function isManuallyExecutable()
+    public function isManuallyExecutable() : bool
     {
         return true;
     }
     
-    /**
-     * Cron job has custom settings in the cron job admin section
-     *
-     * @return boolean
-     */
-    public function hasCustomSettings()
+    public function hasCustomSettings() : bool
     {
         return true;
     }
     
-    public function run()
+    public function run() : ilCronJobResult
     {
         try {
             $logger = new ilEventoImportLogger($this->db);
@@ -185,15 +142,10 @@ class ilEventoImportImport extends ilCronJob
             return new ilEventoImportResult(ilEventoImportResult::STATUS_CRASHED, 'Cron job crashed: ' . $e->getMessage());
         }
     }
-
-    /**
-     * @param RequestClientService $data_source
-     * @param ImporterApiSettings  $api_settings
-     * @param ilEventoImportLogger $logger
-     */
-    public function runDailyFullImport(RequestClientService $data_source, ImporterApiSettings $api_settings, \ilEventoImportLogger $logger)
+    
+    public function runDailyFullImport(RequestClientService $data_source, ImporterApiSettings $api_settings, \ilEventoImportLogger $logger) : void
     {
-        $user_importer = new \EventoImport\communication\EventoUserImporter(
+        $user_importer = new EventoUserImporter(
             $data_source,
             new ilEventoImporterIterator($this->page_size),
             $logger,
@@ -201,7 +153,7 @@ class ilEventoImportImport extends ilCronJob
             $api_settings->getMaxRetries()
         );
 
-        $event_importer = new \EventoImport\communication\EventoEventImporter(
+        $event_importer = new EventoEventImporter(
             $data_source,
             new ilEventoImporterIterator($this->page_size),
             $logger,
@@ -209,22 +161,21 @@ class ilEventoImportImport extends ilCronJob
             $api_settings->getMaxRetries()
         );
 
-        $user_photo_importer = new \EventoImport\communication\EventoUserPhotoImporter(
+        $user_photo_importer = new EventoUserPhotoImporter(
             $data_source,
             $api_settings->getTimeoutFailedRequest(),
             $api_settings->getMaxRetries(),
             $logger
         );
-
-        /* User import */
-        $user_action_factory = new \EventoImport\import\action\user\UserActionFactory(
+        
+        $user_action_factory = new UserActionFactory(
             $this->import_bootstrapping->userFacade(),
             $this->import_bootstrapping->defaultUserSettings(),
             $user_photo_importer,
             $logger
         );
 
-        $user_import_action_decider = new \EventoImport\import\data_matching\UserActionDecider(
+        $user_import_action_decider = new UserActionDecider(
             $this->import_bootstrapping->userFacade(),
             $user_action_factory
         );
@@ -238,15 +189,14 @@ class ilEventoImportImport extends ilCronJob
             $this->db
         );
         $importUsers->run();
-
-        /* Event import */
-        $event_action_factory = new \EventoImport\import\action\event\EventActionFactory(
+        
+        $event_action_factory = new EventActionFactory(
             $this->import_bootstrapping->eventObjectFactory(),
             $this->import_bootstrapping->repositoryFacade(),
             $this->import_bootstrapping->membershipManager(),
             $logger
         );
-        $event_action_decider = new \EventoImport\import\data_matching\EventImportActionDecider(
+        $event_action_decider = new EventImportActionDecider(
             $this->import_bootstrapping->repositoryFacade(),
             $event_action_factory
         );
@@ -254,15 +204,10 @@ class ilEventoImportImport extends ilCronJob
         $import_events = new ilEventoImportImportEventsAndMemberships($event_importer, $event_action_decider, $logger);
         $import_events->run();
     }
-
-    /**
-     * @param RequestClientService $data_source
-     * @param ImporterApiSettings  $api_settings
-     * @param ilEventoImportLogger $logger
-     */
-    public function runHourlyAdminImport(RequestClientService $data_source, ImporterApiSettings $api_settings, \ilEventoImportLogger $logger)
+    
+    public function runHourlyAdminImport(RequestClientService $data_source, ImporterApiSettings $api_settings, \ilEventoImportLogger $logger) : void
     {
-        $admin_importer = new \EventoImport\communication\EventoAdminImporter($data_source, $logger, $api_settings->getTimeoutFailedRequest(), $api_settings->getMaxRetries());
+        $admin_importer = new EventoAdminImporter($data_source, $logger, $api_settings->getTimeoutFailedRequest(), $api_settings->getMaxRetries());
 
         $import_admins = new ilEventoImportImportAdmins(
             $admin_importer,
@@ -272,15 +217,10 @@ class ilEventoImportImport extends ilCronJob
         );
 
         $import_admins->run();
-        ;
     }
-
-    /**
-     * @return bool
-     */
+    
     private function wasFullImportAlreadyRunToday() : bool
     {
-        // Try to get the date from the last run
         $sql = "SELECT * FROM cron_job WHERE job_id = " . $this->db->quote(self::ID, \ilDBConstants::T_TEXT);
         $res = $this->db->query($sql);
         $cron = $this->db->fetchAssoc($res);
@@ -292,25 +232,14 @@ class ilEventoImportImport extends ilCronJob
 
         return date('d.m.Y H:i') == date('d.m.Y H:i', strtotime($cron['job_result_ts']));
     }
-
-    /**
-     * Defines the custom settings form and returns it to plugin slot
-     *
-     * @param ilPropertyFormGUI $a_form
-     */
-    public function addCustomSettingsToForm(ilPropertyFormGUI $a_form)
+    
+    public function addCustomSettingsToForm(ilPropertyFormGUI $a_form) : void
     {
         $conf = new ilEventoImportCronConfig($this->settings, $this->cp);
         $conf->fillCronJobSettingsForm($a_form);
     }
     
-    /**
-     * Saves the custom settings values
-     *
-     * @param ilPropertyFormGUI $a_form
-     * @return boolean
-     */
-    public function saveCustomSettings(ilPropertyFormGUI $a_form)
+    public function saveCustomSettings(ilPropertyFormGUI $a_form) : bool
     {
         $conf = new ilEventoImportCronConfig($this->settings, $this->cp);
 

--- a/classes/class.ilEventoImportImportAdmins.php
+++ b/classes/class.ilEventoImportImportAdmins.php
@@ -1,8 +1,9 @@
-<?php
+<?php declare(strict_types = 1);
 
 use EventoImport\import\db\MembershipManager;
 use EventoImport\communication\EventoAdminImporter;
 use EventoImport\import\db\repository\IliasEventoEventsRepository;
+use EventoImport\communication\api_models\EventoEventIliasAdmins;
 
 class ilEventoImportImportAdmins
 {
@@ -27,7 +28,7 @@ class ilEventoImportImportAdmins
     {
         foreach ($this->evento_importer->fetchAllIliasAdmins() as $data_set) {
             try {
-                $event_admin_list = new \EventoImport\communication\api_models\EventoEventIliasAdmins($data_set);
+                $event_admin_list = new EventoEventIliasAdmins($data_set);
                 $ilias_evento_event = $this->ilias_event_repo->getEventByEventoId($event_admin_list->getEventoId());
 
                 $this->membership_manager->addEventAdmins($event_admin_list, $ilias_evento_event);

--- a/classes/class.ilEventoImportImportEventsAndMemberships.php
+++ b/classes/class.ilEventoImportImportEventsAndMemberships.php
@@ -1,27 +1,49 @@
-<?php
+<?php declare(strict_types = 1);
 
+use EventoImport\communication\EventoEventImporter;
+use EventoImport\import\data_matching\EventImportActionDecider;
+
+/**
+ * Copyright (c) 2017 Hochschule Luzern
+ * This file is part of the EventoImport-Plugin for ILIAS.
+ * EventoImport-Plugin for ILIAS is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * EventoImport-Plugin for ILIAS is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with EventoImport-Plugin for ILIAS.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @author Stephan Winiker <stephan.winiker@hslu.ch>
+ */
 class ilEventoImportImportEventsAndMemberships
 {
-    private $evento_importer;
-    private $event_import_action_decider;
-    private $logger;
+    private EventoEventImporter $evento_importer;
+    private EventImportActionDecider $event_import_action_decider;
+    private \ilEventoImportLogger $logger;
 
     public function __construct(
-        \EventoImport\communication\EventoEventImporter $evento_importer,
-        \EventoImport\import\data_matching\EventImportActionDecider $event_import_action_decider,
-        ilEventoImportLogger $logger
+        EventoEventImporter $evento_importer,
+        EventImportActionDecider $event_import_action_decider,
+        \ilEventoImportLogger $logger
     ) {
         $this->evento_importer = $evento_importer;
         $this->event_import_action_decider = $event_import_action_decider;
         $this->logger = $logger;
     }
 
-    public function run()
+    public function run() : void
     {
         $this->importEvents();
     }
 
-    private function importEvents()
+    private function importEvents() : void
     {
         do {
             try {
@@ -32,7 +54,7 @@ class ilEventoImportImportEventsAndMemberships
         } while ($this->evento_importer->hasMoreData());
     }
 
-    private function importNextEventPage()
+    private function importNextEventPage() : void
     {
         foreach ($this->evento_importer->fetchNextEventDataSet() as $data_set) {
             try {

--- a/classes/class.ilEventoImportPlugin.php
+++ b/classes/class.ilEventoImportPlugin.php
@@ -1,4 +1,7 @@
-<?php
+<?php declare(strict_types = 1);
+
+use  EventoImport\import\db\repository as Repository;
+
 /**
  * Copyright (c) 2017 Hochschule Luzern
  *
@@ -29,37 +32,21 @@ class ilEventoImportPlugin extends ilCronHookPlugin
 {
     const PLUGIN_NAME = "EventoImport";
     
-    /**
-     * @var ilEventoImportPlugin
-     */
-    protected static $instance;
-    
-    /**
-     * @return ilEventoImportPlugin
-     */
-    public static function getInstance()
-    {
-        if (!isset(self::$instance)) {
-            self::$instance = new self();
-        }
-        
-        return self::$instance;
-    }
-    
     public function getPluginName()
     {
         return self::PLUGIN_NAME;
     }
     
     /**
-     * @var  ilEventoImportImport
+     *
+     * @var ilEventoImportImport[]
      */
     protected static $cron_job_instances;
     
     /**
-     * @return  ilEventoImportJobInstances[]
+     * @return  ilEventoImportImport[]
      */
-    public function getCronJobInstances()
+    public function getCronJobInstances() : array
     {
         $this->loadCronJobInstance();
         
@@ -67,7 +54,7 @@ class ilEventoImportPlugin extends ilCronHookPlugin
     }
     
     /**
-     * @return  ilEventoImportJobInstance or false on failure
+     * @return  ilEventoImportImport or false on failure
      */
     public function getCronJobInstance($a_job_id)
     {
@@ -81,33 +68,44 @@ class ilEventoImportPlugin extends ilCronHookPlugin
     
     protected function loadCronJobInstance()
     {
+        global $DIC;
+        $db = $DIC->database();
+        $rbac = $DIC->rbac();
+        $refinery = $DIC->refinery();
+        
+        //This is a workaround to avoid problems with missing templates
+        if (!method_exists($DIC, 'ui') || !method_exists($DIC->ui(), 'factory') || !isset($DIC['ui.factory'])) {
+            ilInitialisation::initUIFramework($DIC);
+            ilStyleDefinition::setCurrentStyle('Desktop');
+        }
+        
         if (!isset(self::$cron_job_instances)) {
-            self::$cron_job_instances[ilEventoImportImport::ID] = new ilEventoImportImport();
+            self::$cron_job_instances[ilEventoImportImport::ID] = new ilEventoImportImport($this, $rbac, $db, $refinery, new ilSetting('crevento'));
         }
     }
 
     protected function beforeUninstall()
     {
-        /** @var $ilDB ilDBInterface */
-        global $ilDB;
-
+        global $DIC;
+        $db = $DIC->database();
+        
         $drop_table_list = [
             'crnhk_crevento_usrs',
             'crnhk_crevento_mas',
             'crnhk_crevento_subs',
-            \EventoImport\import\db\repository\EventoUserRepository::TABLE_NAME,
-            \EventoImport\import\db\repository\IliasEventoEventsRepository::TABLE_NAME,
-            \EventoImport\import\db\repository\ParentEventRepository::TABLE_NAME,
-            \EventoImport\import\db\repository\EventLocationsRepository::TABLE_NAME,
-            \EventoImport\import\db\repository\EventMembershipRepository::TABLE_NAME,
+            Repository\EventoUserRepository::TABLE_NAME,
+            Repository\IliasEventoEventsRepository::TABLE_NAME,
+            Repository\ParentEventRepository::TABLE_NAME,
+            Repository\EventLocationsRepository::TABLE_NAME,
+            Repository\EventMembershipRepository::TABLE_NAME,
             ilEventoImportLogger::TABLE_LOG_USERS,
             ilEventoImportLogger::TABLE_LOG_EVENTS,
             ilEventoImportLogger::TABLE_LOG_MEMBERSHIPS
         ];
 
         foreach ($drop_table_list as $key => $table) {
-            if ($ilDB->tableExists($table)) {
-                $ilDB->dropTable($table);
+            if ($db->tableExists($table)) {
+                $db->dropTable($table);
             }
         }
 

--- a/classes/class.ilEventoImportResult.php
+++ b/classes/class.ilEventoImportResult.php
@@ -3,17 +3,17 @@
  * Copyright (c) 2017 Hochschule Luzern
  *
  * This file is part of the EventoImport-Plugin for ILIAS.
- 
+
  * EventoImport-Plugin for ILIAS is free software: you can redistribute
  * it and/or modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- 
+
  * EventoImport-Plugin for ILIAS is distributed in the hope that
  * it will be useful, but WITHOUT ANY WARRANTY; without even the implied
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- 
+
  * You should have received a copy of the GNU General Public License
  * along with EventoImport-Plugin for ILIAS.  If not,
  * see <http://www.gnu.org/licenses/>.
@@ -24,16 +24,17 @@
  *
  * @author Stephan Winiker <stephan.winiker@hslu.ch>
  */
-class ilEventoImportResult extends ilCronJobResult {
+class ilEventoImportResult extends ilCronJobResult
+{
 
-	/**
-	 * @param      $status  int
-	 * @param      $message string
-	 * @param null $code    string
-	 */
-	public function __construct($status, $message) {
-		$this->setStatus($status);
-		$this->setMessage($message);
-	}
+    /**
+     * @param      $status  int
+     * @param      $message string
+     * @param null $code    string
+     */
+    public function __construct($status, $message)
+    {
+        $this->setStatus($status);
+        $this->setMessage($message);
+    }
 }
-?>

--- a/classes/class.ilEventoImporter.php
+++ b/classes/class.ilEventoImporter.php
@@ -1,4 +1,7 @@
-<?php
+<?php declare(strict_types = 1);
+
+use EventoImport\communication\request_services\RequestClientService;
+
 /**
  * Copyright (c) 2017 Hochschule Luzern
  *
@@ -19,8 +22,6 @@
  * see <http://www.gnu.org/licenses/>.
  */
 
-use EventoImport\communication\request_services\RequestClientService;
-
 /**
  * Class ilEventoImporter
  *
@@ -29,11 +30,11 @@ use EventoImport\communication\request_services\RequestClientService;
 
 abstract class ilEventoImporter
 {
-    protected $data_source;
-    protected $seconds_before_retry;
-    protected $max_retries;
-    protected $evento_logger;
-    protected $has_more_data;
+    protected RequestClientService $data_source;
+    protected int $seconds_before_retry;
+    protected int $max_retries;
+    protected ilEventoImportLogger $evento_logger;
+    protected bool $has_more_data;
 
     public function __construct(
         RequestClientService $data_source,

--- a/classes/class.ilEventoImporterIterator.php
+++ b/classes/class.ilEventoImporterIterator.php
@@ -1,50 +1,51 @@
-<?php
+<?php declare(strict_types = 1);
+
 /**
  * Copyright (c) 2017 Hochschule Luzern
  *
  * This file is part of the EventoImport-Plugin for ILIAS.
- 
+
  * EventoImport-Plugin for ILIAS is free software: you can redistribute
  * it and/or modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- 
+
  * EventoImport-Plugin for ILIAS is distributed in the hope that
  * it will be useful, but WITHOUT ANY WARRANTY; without even the implied
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- 
+
  * You should have received a copy of the GNU General Public License
  * along with EventoImport-Plugin for ILIAS.  If not,
  * see <http://www.gnu.org/licenses/>.
  */
 
 /**
- * Class ilEventoImporterIterator
- *
  * @author Stephan Winiker <stephan.winiker@hslu.ch>
  */
 
-class ilEventoImporterIterator {
-	private $page;
-	private $page_size;
-	
-	public function __construct(int $page_size) {
-		$this->page = 1;
-		$this->page_size = $page_size;
-	}
-	
-	public function nextPage() : int
+class ilEventoImporterIterator
+{
+    private int $page;
+    private int $page_size;
+    
+    public function __construct(int $page_size)
     {
-		return $this->page++;
-	}
-	
-	public function getPage() : int
+        $this->page = 1;
+        $this->page_size = $page_size;
+    }
+    
+    public function nextPage() : int
     {
-		return $this->page;
-	}
+        return $this->page++;
+    }
+    
+    public function getPage() : int
+    {
+        return $this->page;
+    }
 
-	public function getPageSize() : int
+    public function getPageSize() : int
     {
         return $this->page_size;
     }

--- a/classes/import/EventoImportBootstrap.php
+++ b/classes/import/EventoImportBootstrap.php
@@ -1,14 +1,14 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace EventoImport\import;
 
+use ILIAS\DI\RBACServices;
 use EventoImport\import\db\repository\EventoUserRepository;
 use EventoImport\import\db\repository\IliasEventoEventsRepository;
 use EventoImport\import\db\query\IliasUserQuerying;
 use EventoImport\import\db\UserFacade;
 use EventoImport\import\db\query\IliasEventObjectQuery;
 use EventoImport\import\db\RepositoryFacade;
-use ILIAS\DI\RBACServices;
 use EventoImport\import\db\repository\EventMembershipRepository;
 use EventoImport\import\db\repository\EventLocationsRepository;
 use EventoImport\import\db\repository\ParentEventRepository;
@@ -21,67 +21,40 @@ class EventoImportBootstrap
     /*********************
      ** General objects **
      *********************/
-    /** @var \ilDBInterface */
     private \ilDBInterface $db;
-
-    /** @var RBACServices */
     private RBACServices $rbac_services;
-
-    /** @var \ilSetting */
     private \ilSetting $settings;
-
-    /** @var \ilEventoImportLogger */
     private \ilEventoImportLogger $logger;
 
-    /*** User related objects ***/
-    /** @var EventoUserRepository */
+    /***************************
+     ** User related objects **
+     ***************************/
     private EventoUserRepository $evento_user_repository;
-
-    /** @var IliasUserQuerying */
     private IliasUserQuerying $user_query;
-
-    /** @var UserFacade */
     private UserFacade $user_facade;
 
     /***************************
      ** Event related objects **
      ***************************/
-    /** @var IliasEventoEventsRepository */
     private IliasEventoEventsRepository $evento_event_repository;
-
-    /** @var IliasEventObjectQuery */
     private IliasEventObjectQuery $event_query;
-
-    /** @var EventLocationsRepository */
     private EventLocationsRepository $location_repository;
-
-    /** @var ParentEventRepository */
     private ParentEventRepository $parent_event_repo;
-
-    /** @var RepositoryFacade */
     private RepositoryFacade $repository_facade;
-
-    /** @var IliasEventObjectFactory */
     private IliasEventObjectFactory $event_object_factory;
-
-    /** @var DefaultEventSettings */
     private DefaultEventSettings $default_event_settings;
 
-    /*****************
-     *** Membership **
-     *****************/
-    /** @var EventMembershipRepository */
+    /*********************************
+     *** Membership related objects **
+     ********************************/
     private EventMembershipRepository $membership_repo;
-
-    /** @var MembershipManager */
     private MembershipManager $membership_manager;
 
-    public function __construct(\ilDBInterface $db = null, RBACServices $rbac_services = null, \ilSetting $settings = null)
+    public function __construct(\ilDBInterface $db, RBACServices $rbac_services, \ilSetting $settings)
     {
-        global $DIC;
-        $this->db = $db ?? $DIC->database();
-        $this->rbac_services = $rbac_services ?? $DIC->rbac();
-        $this->settings = $settings ?? new \ilSetting('crevento');
+        $this->db = $db;
+        $this->rbac_services = $rbac_services;
+        $this->settings = $settings;
     }
 
     public function logger() : \ilEventoImportLogger

--- a/classes/import/db/repository/EventoUserRepository.php
+++ b/classes/import/db/repository/EventoUserRepository.php
@@ -15,8 +15,7 @@ class EventoUserRepository
     public const COL_EVENTO_ID = 'evento_id';
     public const COL_ILIAS_USER_ID = 'ilias_user_id';
     public const COL_LAST_TIME_DELIVERED = 'last_time_delivered';
-
-    /** @var \ilDBInterface */
+    
     private \ilDBInterface $db;
 
     /**

--- a/classes/import/db/repository/IliasEventoEventsRepository.php
+++ b/classes/import/db/repository/IliasEventoEventsRepository.php
@@ -2,7 +2,6 @@
 
 namespace EventoImport\import\db\repository;
 
-use EventoImport\communication\api_models\EventoEvent;
 use EventoImport\import\db\model\IliasEventoEvent;
 
 /**

--- a/classes/import/settings/DefaultEventSettings.php
+++ b/classes/import/settings/DefaultEventSettings.php
@@ -4,10 +4,10 @@ namespace EventoImport\import\settings;
 
 class DefaultEventSettings
 {
-    private $default_object_owner_id;
-    private $default_sort_mode;
-    private $default_sort_direction;
-    private $default_online_status;
+    private int $default_object_owner_id;
+    private int $default_sort_mode;
+    private int $default_sort_direction;
+    private bool $default_online_status;
 
     public function __construct(\ilSetting $settings)
     {

--- a/classes/import/settings/DefaultUserSettings.php
+++ b/classes/import/settings/DefaultUserSettings.php
@@ -6,9 +6,9 @@ use ILIAS\UI\Implementation\Component\Input\Field\DateTime;
 
 class DefaultUserSettings
 {
-    private $settings;
+    private \ilSetting $settings;
 
-    private $now;
+    private \DateTime $now;
     private $auth_mode;
     private $is_auth_mode_ldap;
     private $is_profile_public;

--- a/exceptions/class.ilEventoImportApiDataException.php
+++ b/exceptions/class.ilEventoImportApiDataException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 class ilEventoImportApiDataException extends ilException
 {

--- a/exceptions/class.ilEventoImportCommunicationException.php
+++ b/exceptions/class.ilEventoImportCommunicationException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 class ilEventoImportCommunicationException extends ilException
 {


### PR DESCRIPTION
Lieber @rsheer 

Das ist einfach eine erste Version, damit du weiterarbeiten kannst. Lass uns dies dann am Mittwoch zusammen anschauen.

Vielen Dank für die ganze Arbeit am EventoImport. Ich habe beim Durchschauen gleich ein paar Dinge angepasst, du findest diese in diesem PR.

Ein Fehler, der mir beim Verwenden aufgefallen ist, habe ich als Issue gemeldet.

Cool, dass wir nichts statitisches im Code haben!

Ich füge gleich hier noch die allgemeinen Punkte hinzu.

Please answer the following questions:
- [x] Der `EventoImportBootstrap` fühlt sich an wie ein kaputter DIC. Was ist genau seine Funktion? Es scheint irgendetwas mit Lazy-Loading zu tun zu haben, aber dann verstehe ich nicht ganz, warum der Logger so geladen werden sollte.
- [ ] Sind wirklich all diese verschiedenen "Patterns" nötig? Wir haben da: Einen Manager, ein paar Repositories, zwei Facaden (wobei die RepositoryFacade unter anderem auch Repositories zurückgibt), eine Reihe von Modellen (die sich nach DTOs anfühlen), ...
- [x] Dies müsste weg, richtig: https://github.com/HochschuleLuzern/EventoImport/tree/evento_import_ng/classes/shared?
- [x] Was ist denn die Begründung, um die Query-Klassen in ein eigenes Packet zu stecken? Die `User` und die `Event`- Tabelle (Achtung: Bitte Namensschema anpassen "Query" vs. "Querying") scheinen eine Art Crud-Aspraktion zu sein (warum ist dies nicht in den Repositories, diese sollten doch solche Dinge kapseln?), die `Membershipable` - Tabelle scheint sich hingegen vor allem um Objekte im Tree zu kümmern. Sie scheinen also eine Art "Hilfe"-Funktion zu haben. Wäre es nicht sinnvoll die `Event`und die `User`- Query-Klassen in die entsprechenden Repositories zu verschieben?

Please consider the following suggestions. You do not need to follow those, but but please indicate shortly why you prefer to do otherwi
- [x] Die Funktion `EventoUserRepository::fetchNotImportedUsers` scheint nicht wirklich das zu tun, was der Name behauptet. Wenn ich dies richtig verstehe sollte sie `fetchUsersWithLastImportOlderThanOneWeek`.
- [x] Die Funktion `EventoUserImporter::fetchUserDataRecordById($id)` scheint für nicht existierende Benutzer mehrere Rückgabewerte zu kennen (null || array()). Das scheint mir nicht sinnvoll. Gibt es noch mehr solche Funktionen, die unklare Rückgabewerte liefern?
- [ ] Der Aufbau der Klassen ist nicht immer ganz durchsichtig: Es gibt eine `RepositoryFacade` und eine `UserFacade`, aber `DefaultEventSettings`und `DefaultUserSettings` und dann wieder eine ganze Reihe an `Repositories` und dann nochmals andere `Models`.
- [x] In der Klasse `EventImportActionDecider` gibt es drei verschiedene Patterns für Verzweigungen. Zudem gibt es, so wie es aussieht einen Weg durch die Funktion "determineActionForExistingIliasEventoEvent", der zu gar keiner Aktion führt, und dann scheinen da noch die beiden Funktionen `moveFromEventoUnmarkedEventToTrash` `createNewEventOverDatasetOfExistingOne`, gar nicht implementiert zu sein, ...oder was verpasse ich gerade?


Please implement the following changes:
- [x] Bitte verschiebe jegliche Nutzung des ILIAS-DIC in die Einstiegsklasse und entferne alle "global $DIC" aus dem Code, ausser dort, wo es absolut nötig ist. In der Folge auch alle optionalen Parameter entfernen, falls es nicht absolut unumgänglich ist.
- [x] Bitte verschiebe auch meine alten Klassen noch in den Namespace (z.B. der Logger), sonst wirkt dies sehr inkonsistent und nur historisch begründet.
- [x] Wenn ich dies richtig verstehe, dann haben `UserActionDecider` und `EventImportActionDecider` die gleiche Funktion. Dann sollten sie aber auch dem gleichen Namensschema folgen. Ich schlage vor `UserActionDecider` in `UserImportActionDecider` umzubenennen, da dies verboser ist.
- [x] Im Konstruktor von `ilEventoImportImport` wird eine magische page_size gesetzt. Bitte umbauen.
- [x] In der Funktion `wasFullImportAlreadyRunToday` wird SQL-Code im Controller ausgeführt. Das ist keine gute Idee. Müsste irgendwo in einem Repository verschwinden.
- [x] Bitte alle Klassen mit `declare(strict_types = 1)`versehen und alle Variablen und Funktionen typisieren.
- [x] Bitte alle unnötigen Typehints entfernen. Es sollten nur noch im Falle von Arrays oder falls ein mixed Returntype absolut unumgänglich ist Hints vorhanden sein.

Liebe Grüsse,
Stephan