### PR TITLE
Removing Lockdown-Accounts from import

### DIFF
--- a/classes/communication/interface_models/EventoUser.php
+++ b/classes/communication/interface_models/EventoUser.php
@@ -13,6 +13,7 @@ class EventoUser extends ApiDataModelBase
     const JSON_EMAIL_2 = 'email2';
     const JSON_EMAIL_3 = 'email3';
     const JSON_ROLES = 'roles';
+    const JSON_IS_LOCKDOWN_ACCOUNT = 'isLockdownAccount';
 
     private ?int $evento_id;
     private ?string $last_name;
@@ -21,6 +22,7 @@ class EventoUser extends ApiDataModelBase
     private ?string $login_name;
     private ?array $email_list;
     private ?array $roles;
+    private ?bool $is_lockdown_account;
 
     public function __construct(array $data_set)
     {
@@ -31,6 +33,7 @@ class EventoUser extends ApiDataModelBase
         $this->login_name = $this->validateAndReturnString($data_set, self::JSON_LOGIN_NAME);
         $this->email_list = $this->validateCombineAndReturnListOfNonEmptyStrings($data_set, [self::JSON_EMAIL, self::JSON_EMAIL_2, self::JSON_EMAIL_3], false);
         $this->roles = $this->validateAndReturnArray($data_set, self::JSON_ROLES);
+        $this->is_lockdown_account = $this->validateAndReturnBoolean($data_set, self::JSON_IS_LOCKDOWN_ACCOUNT, false, false) ?? false;
 
         $this->decoded_api_data = $data_set;
         $this->checkErrorsAndMaybeThrowException();
@@ -69,6 +72,11 @@ class EventoUser extends ApiDataModelBase
     public function getRoles() : array
     {
         return $this->roles;
+    }
+
+    public function isLockdownAccount() : bool
+    {
+        return $this->is_lockdown_account;
     }
 
     public function getDecodedApiData() : array

--- a/classes/communication/interface_models/JSONDataValidator.php
+++ b/classes/communication/interface_models/JSONDataValidator.php
@@ -41,16 +41,12 @@ trait JSONDataValidator
         return $data_array[$key];
     }
 
-    /**
-     * @param array  $data_array
-     * @param string $key
-     * @param bool   $as_string_possible
-     * @return bool|null
-     */
-    protected function validateAndReturnBoolean(array $data_array, string $key, bool $as_string_possible = false) : ?bool
+    protected function validateAndReturnBoolean(array $data_array, string $key, bool $as_string_possible = false, bool $is_mandatory = true) : ?bool
     {
         if (!isset($data_array[$key])) {
-            $this->key_errors[$key] = 'Value not set';
+            if ($is_mandatory) {
+                $this->key_errors[$key] = 'Value not set';
+            }
             return null;
         }
 

--- a/classes/import/Logger.php
+++ b/classes/import/Logger.php
@@ -79,7 +79,11 @@ class Logger
     const CREVENTO_USR_UPDATED = 302;
     const CREVENTO_USR_RENAMED = 303;
     const CREVENTO_USR_CONVERTED = 304;
+    const CREVENTO_USR_LOCKDOWN = 305;
+
+
     const CREVENTO_USR_NOTICE_CONFLICT = 313;
+
     const CREVENTO_USR_ERROR_ERROR = 324;
 
     const TABLE_LOG_USERS = 'crevento_log_users';

--- a/classes/import/UserImportTask.php
+++ b/classes/import/UserImportTask.php
@@ -72,13 +72,7 @@ class UserImportTask
                 $evento_user = new EventoUser($data_set);
 
                 if ($evento_user->isLockdownAccount()) {
-                    $this->evento_user_repo->deleteEventoIliasUserConnectionByEventoId($evento_user->getEventoId());
-                    $this->evento_logger->logUserImport(
-                        Logger::CREVENTO_USR_LOCKDOWN,
-                        $evento_user->getEventoId(),
-                        $evento_user->getLoginName(),
-                        ['api_data' => $evento_user->getDecodedApiData()]
-                    );
+                    $this->handleDeliveredLockdownAccount($evento_user);
                 } else {
                     $action = $this->user_import_action_decider->determineImportAction($evento_user);
                     $action->executeAction();
@@ -96,6 +90,23 @@ class UserImportTask
                 $this->evento_logger->logException('User Import', $e->getMessage());
             }
         }
+    }
+
+    private function handleDeliveredLockdownAccount(EventoUser $evento_user)
+    {
+        $ilias_user_id = $this->evento_user_repo->getIliasUserIdByEventoId($evento_user->getEventoId());
+        $this->evento_user_repo->deleteEventoIliasUserConnectionByEventoId($evento_user->getEventoId());
+
+        if (!is_null($ilias_user_id)) {
+            $ilias_user_obj = $this->ilias_user_service->getExistingIliasUserObjectById($ilias_user_id);
+            $this->ilias_user_service->deactivateUserAccount($ilias_user_obj);
+        }
+        $this->evento_logger->logUserImport(
+            Logger::CREVENTO_USR_LOCKDOWN,
+            $evento_user->getEventoId(),
+            $evento_user->getLoginName(),
+            ['api_data' => $evento_user->getDecodedApiData()]
+        );
     }
 
     /**

--- a/classes/import/data_management/ilias_core_services/IliasUserServices.php
+++ b/classes/import/data_management/ilias_core_services/IliasUserServices.php
@@ -240,4 +240,17 @@ class IliasUserServices
             . " WHERE DATEDIFF(FROM_UNIXTIME(time_limit_until),create_date)< " . $this->db->quote($min_threshold_in_days, \ilDBConstants::T_INTEGER);
         $this->db->manipulate($q);
     }
+
+    public function deactivateUserAccount(\ilObjUser $ilias_user)
+    {
+        // Deassign user from HSLU roles
+        foreach ($this->user_settings->getEventoCodeToIliasRoleMapping() as $evento_role_code => $ilias_role_id) {
+            $this->deassignUserFromRole($ilias_user->getId, $ilias_role_id);
+        }
+
+        // Set user auth mode to default (local auth) and set expiration date to now
+        $ilias_user->setAuthMode('local');
+        $ilias_user->setTimeLimitUntil($this->user_settings->getNow()->getTimestamp()); // Set user expiration date to now
+        $ilias_user->update();
+    }
 }


### PR DESCRIPTION
This PR attempts to remove the lockdown accounts from the evento import. Since it is technically difficult to remove the accounts from the Evento-API, they have to be removed on the ILIAS side of the import.

The API now adds an `isLockdownAccount`-Field with a boolean `true` or `false` set.

I have made two commits for this PR:
The first one was to add the new API field to the importer and to delete the ILIAS-Evento Connection for the user account.
The second one is to deactivate the account entirely and remove it from HSLU-Roles. Without this commit, the account just stays as an LDAP-Account for a year till it expires.